### PR TITLE
fix: remove vendor and git dir from image

### DIFF
--- a/Dockerfile.nvidia
+++ b/Dockerfile.nvidia
@@ -28,6 +28,7 @@ COPY --from=0 /go/src/github.com/Mellanox/whereabouts/bin/node-slice-controller 
 
 # Provide the source code and license in the container
 COPY --from=0 /usr/src/whereabouts .
+RUN rm -rf vendor .git
 COPY script/install-cni.sh .
 COPY script/lib.sh .
 COPY script/token-watcher.sh .


### PR DESCRIPTION
Security is giving false positives on vendor dir.
git dir is recommended to not be included in container image.

<!--  Thanks for sending a pull request!
Please describe accurately what this PR does, and why we need it.
Please make sure to point to whatever issues it fixes.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer** *(optional)*:

